### PR TITLE
Fixed event matching problem in LoadGenieEvent. 

### DIFF
--- a/UserTools/LoadGenieEvent/LoadGenieEvent.cpp
+++ b/UserTools/LoadGenieEvent/LoadGenieEvent.cpp
@@ -145,7 +145,9 @@ bool LoadGenieEvent::Execute(){
                         inputfiles = filedir+"/"+inputfiles;
                         if(verbosity) std::cout << "Tool LoadGenieEvent: Loading Genie file: " << inputfiles << std::endl;
                 }
-                m_data->CStore.Get("GenieEntry",tchainentrynum);
+		std::string genieentry;
+                m_data->CStore.Get("GenieEntry",genieentry);
+		tchainentrynum = std::stoi(genieentry);
                 if(!get_ok){
                         if(verbosity) std::cout << "Tool LoadGenieEvent: Failed to find GenieEntry in CStore" << std::endl;
                         return false;
@@ -184,7 +186,8 @@ bool LoadGenieEvent::Execute(){
 		uint16_t MCTriggernum;
 		m_data->Stores["ANNIEEvent"]->Get("MCTriggernum",MCTriggernum);
 		if (MCTriggernum != 0){
-			m_data->CStore.Set("NewGENIEEntry",false);	
+			m_data->CStore.Set("NewGENIEEntry",false);
+			tchainentrynum++;
 			return true;	//Don't evaluate new GENIE event for dealyed WCSim triggers
 		} else {
 			m_data->CStore.Set("NewGENIEEntry",true);

--- a/UserTools/LoadGenieEvent/LoadGenieEvent.h
+++ b/UserTools/LoadGenieEvent/LoadGenieEvent.h
@@ -103,8 +103,6 @@ class LoadGenieEvent: public Tool {
 	std::string currentfilestring;
 	unsigned long local_entry=0;           // 
 	unsigned int tchainentrynum=0;         // 
-	bool manualmatch=0;			//to be used when GENIE information is not stored properly in file
-	int fileevents=0;
 
 	// common input/output variables to both Robert/Zarko filesets
 	int parentpdg;

--- a/UserTools/LoadGenieEvent/README.md
+++ b/UserTools/LoadGenieEvent/README.md
@@ -5,8 +5,10 @@ The `LoadGenieEvent` tool loads information from the GENIE files about the neutr
 ## Configurations ##
 
 It is possible to look at GENIE files on their own (without corresponding WCSim files), in this case the `FileDir` and `FilePattern` need to be specified in the configuration file.
-If one wants to get corresponding GENIE information for WCSim files, one should specify `LoadWCSimTool` in the `FilePattern` row. In this case the tool will try to extract the information about the corresponding GENIE file from the WCSim file and load the respective GENIE file automatically. For newer files, the path should be saved alongside the filename and one can set the `FileDir` to `NA`. For older files, only the filename is saved and one needs to specify the `FileDir` in which the GENIE files are to be found by hand.
+If one wants to get corresponding GENIE information for WCSim files, one should specify `LoadWCSimTool` in the `FilePattern` row. In this case the tool will try to extract the information about the corresponding GENIE file from the WCSim file and load the respective GENIE file automatically. For newer files, the path is SOMETIMES(*see below*) saved alongside the filename and one can set the `FileDir` to `NA`. For older files, only the filename is saved and one needs to specify the `FileDir` in which the GENIE files are to be found by hand.
 Note that a lot of WCSim files do not have the complete information about their GENIE files saved. In this case, a manual matching of GENIE files to WCSim files is possible, although the following restrictions to the naming apply: The WCSim files must have the same nomenclature as Marcus' WCSim beam files, i.e. `wcsim_0.X.Y.root`, where `X` is the number of the corresponding GENIE file, and `Y` specifies which part of the GENIE file is being looked at, with each WCSim file corresponding to 500 entries in a GENIE file. The matching GENIE file would be called `ghtp.X.ghep.root`, with the events `Y*(500) ... (Y+1)*500` corresponding to the events in the WCSim file. 
+Due to delayed WCSim triggers, there is not a 1:1 matching of GENIE events to WCSim events. For a delayed WCSim trigger, the Genie event must be skipped, so not all GENIE events in the GHEP file will be present from the WCSim file. Therefore, the WCSim file MUST contain the GENIE event number in order for that event to be read in.
+If the WCSim file was generated from offset GENIE events (a non-zero Y in the WCSim file name), then the WCSim only saved the file path of the GENIE file, not the filename. IT IS STRONGLY RECOMMENDED to set the FileDir to the GENIE file location.
 
 ## GenieInfo BoostStore ##
 
@@ -88,15 +90,11 @@ LoadGenieEvent has the following configuration options:
 
 ```
 verbosity 1
-FluxVersion 0   #0: rhatcher files, 1: zarko files
+FluxVersion 1   #0: rhatcher files, 1: zarko files
 #FileDir NA     #specify "NA" for newer files: full path is saved in WCSim
 FileDir /pnfs/annie/persistent/users/vfischer/genie_files/BNB_Water_10k_22-05-17
 #FileDir /pnfs/annie/persistent/users/moflaher/genie/BNB_World_10k_11-03-18_gsimpleflux
 #FilePattern gntp.*.ghep.root  ## for specifying specific files to load
 FilePattern LoadWCSimTool      ## use this pattern to load corresponding genie info with the LoadWCSimTool
-                               ## N.B: FileDir must still be specified for now! (WCSim files do not record their directory)
-ManualFileMatching 1           ## If the corresponding GENIE files are not saved reliably, a manual matching of WCSim files to GENIE files can take place
-FileEvents 500                 ## Number of events per WCSim file
-                               ## 500 events for Marcus files
-                               ## 1000 events for James files
+                               ## N.B: FileDir must still be specified for now!
 ```

--- a/UserTools/LoadWCSim/LoadWCSim.cpp
+++ b/UserTools/LoadWCSim/LoadWCSim.cpp
@@ -412,7 +412,7 @@ bool LoadWCSim::Execute(){
 			int genieentry = firsttrigt->GetHeader()->GetGenieEntryNum();
 			/*if(verbosity>3)*/ cout<<"Genie file is "<<geniefilename<<", genie event num was "<<genieentry<<endl;
 			m_data->CStore.Set("GenieFile",geniefilename);
-			m_data->CStore.Set("GenieEntry",genieentry);
+			m_data->CStore.Set("GenieEntry",std::to_string(genieentry));
 			
 			for(int trigi=0; trigi<WCSimEntry->wcsimrootevent->GetNumberOfEvents(); trigi++){
 				

--- a/configfiles/LoadGenieEvents/LoadGenieEventConfig
+++ b/configfiles/LoadGenieEvents/LoadGenieEventConfig
@@ -1,5 +1,5 @@
 verbosity 100
-FluxVersion 0  # use 0 to load genie files based on bnb_annie_0000.root etc files
+FluxVersion 1  # use 0 to load genie files based on bnb_annie_0000.root etc files
                # use 1 to load files based on beammc_annie_0000.root etc files
 FileDir NA     # specify "NA" for newer files: full path is saved in WCSim
 #FileDir /pnfs/annie/persistent/users/vfischer/genie_files/BNB_Water_10k_22-05-17
@@ -8,8 +8,4 @@ FileDir NA     # specify "NA" for newer files: full path is saved in WCSim
 #FileDir .                     ## Use with grid
 #FilePattern gntp.*.ghep.root  ## for specifying specific files to load
 FilePattern LoadWCSimTool      ## use this pattern to load corresponding genie info with the LoadWCSimTool
-                               ## N.B: FileDir must still be specified for now! (WCSim files do not record their directory)
-ManualFileMatching 0           ## to manually match GENIE event to corresponding WCSim event
-FileEvents 1000                ## number of events in the WCSim file
-                               ## 500 for Marcus files
-                               ## 1000 for James files
+                               ## N.B: FileDir must still be specified for now!

--- a/configfiles/ReweightEventsGenie/LoadGenieEventConfig
+++ b/configfiles/ReweightEventsGenie/LoadGenieEventConfig
@@ -1,5 +1,5 @@
 verbosity 100
-FluxVersion 0  # use 0 to load genie files based on bnb_annie_0000.root etc files
+FluxVersion 1  # use 0 to load genie files based on bnb_annie_0000.root etc files
                # use 1 to load files based on beammc_annie_0000.root etc files
 FileDir NA     # specify "NA" for newer files: full path is saved in WCSim
 #FileDir /pnfs/annie/persistent/users/vfischer/genie_files/BNB_Water_10k_22-05-17
@@ -8,8 +8,4 @@ FileDir NA     # specify "NA" for newer files: full path is saved in WCSim
 #FileDir .                     ## Use with grid
 #FilePattern gntp.*.ghep.root  ## for specifying specific files to load
 FilePattern LoadWCSimTool      ## use this pattern to load corresponding genie info with the LoadWCSimTool
-                               ## N.B: FileDir must still be specified for now! (WCSim files do not record their directory)
-ManualFileMatching 0           ## to manually match GENIE event to corresponding WCSim event
-FileEvents 1000                ## number of events in the WCSim file
-                               ## 500 for Marcus files
-                               ## 1000 for James files
+                               ## N.B: FileDir must still be specified for now!


### PR DESCRIPTION
Genie Event number is read in properly when not using manual matching.
Genie event number is kept consistent with WCSim file when manual matching
Made GenieEntry savable to CStore in LoadWCSim by saving as string instead of int.